### PR TITLE
feat(profile): add recommendation panel, per-stat status icons, and s…

### DIFF
--- a/src/core/calculate.js
+++ b/src/core/calculate.js
@@ -60,45 +60,81 @@ export function bestPerToken(pairs, {relax=false}={}) {
   return [...bucket.values()];
 }
 
-export function scoreAndRecommend(rows){
-  for (const r of rows){
-    const vol24 = nz(r.volume.h24), liq = nz(r.liquidityUsd), fdv = nz(r.fdv);
-    const ch1 = nz(r.change.h1), ch6 = nz(r.change.h6), ch24 = nz(r.change.h24), ch5 = nz(r.change.m5);
-    const tx = nz(r.txns.h24);
+export function scoreAndRecommendOne(r) {
+  const out = { ...r, change: { ...r?.change }, volume: { ...r?.volume }, txns: { ...r?.txns } };
 
-    const nVol = normLog(vol24,6);
-    const nLiq = normLog(liq,6);
-    const momRaw  = clamp((ch1+ch6+ch24)/100, -1, 1);
-    const nMom  = momRaw>0 ? momRaw : momRaw*0.5; 
-    const nAct = normLog(tx,4);
+  const vol24 = nz(out.volume?.h24);
+  const liq   = nz(out.liquidityUsd);
+  const fdv   = nz(out.fdv);
 
-    let score = RANK_WEIGHTS.volume*nVol + RANK_WEIGHTS.liquidity*nLiq
-              + RANK_WEIGHTS.momentum*nMom + RANK_WEIGHTS.activity*nAct;
+  const ch5  = nz(out.change?.m5);
+  const ch1  = nz(out.change?.h1);
+  const ch6  = nz(out.change?.h6);
+  const ch24 = nz(out.change?.h24);
 
-    let penaltyApplied = false;
-    if (liq>0 && fdv/Math.max(liq,1) > FDV_LIQ_PENALTY.ratio) { score -= FDV_LIQ_PENALTY.penalty; penaltyApplied=true; }
-    score = clamp(score,0,1);
+  const tx   = nz(out.txns?.h24);
 
-    let rec='AVOID', why=['Weak composite score'];
-    if (score>=BUY_RULES.score && liq>=BUY_RULES.liq && vol24>=BUY_RULES.vol24 && ch1>BUY_RULES.change1h) {
-      rec='GOOD'; why=['Strong composite score'];
-      if (ch1>0) why.push('Positive 1h momentum');
-      if (ch24>0) why.push('Up over 24h');
-      if (liq>0) why.push('Healthy liquidity');
-      if (vol24>0) why.push('Active trading volume');
-    } else if (score>=0.40) {
-      rec='WATCH'; why=['Decent composite score'];
-      if (ch1<0) why.push('Short-term dip (entry risk)');
-      if (penaltyApplied) why.push('FDV/liquidity imbalance');
-    } else {
-      if (ch24<0) why.push('Down over 24h');
-      if (liq<25_000) why.push('Thin liquidity');
-      if (vol24<50_000) why.push('Low trading activity');
-    }
+  const nVol = normLog(vol24, 6);
+  const nLiq = normLog(liq,   6);
+  const momRaw = clamp((ch1 + ch6 + ch24) / 100, -1, 1);
+  const nMom = momRaw > 0 ? momRaw : momRaw * 0.5; 
+  const nAct = normLog(tx, 4);
 
-    r.score=score; r.recommendation=rec; r.why=why;
-    r._norm = { nVol, nLiq, nMom: clamp((nMom+1)/2,0,1), nAct }; // normalize mom to 0..1 for bars
-    r._chg  = [ch5, ch1, ch6, ch24]; // for sparkline
+  let score =
+      RANK_WEIGHTS.volume    * nVol +
+      RANK_WEIGHTS.liquidity * nLiq +
+      RANK_WEIGHTS.momentum  * nMom +
+      RANK_WEIGHTS.activity  * nAct;
+
+  let penaltyApplied = false;
+  if (liq > 0 && fdv / Math.max(liq, 1) > FDV_LIQ_PENALTY.ratio) {
+    score -= FDV_LIQ_PENALTY.penalty;
+    penaltyApplied = true;
   }
-  return rows.sort((a,b)=> b.score-a.score || b.volume.h24-a.volume.h24);
+  score = clamp(score, 0, 1);
+
+  let rec = 'AVOID';
+  let why = ['Weak composite score'];
+
+  if (
+    score >= BUY_RULES.score &&
+    liq   >= BUY_RULES.liq   &&
+    vol24 >= BUY_RULES.vol24 &&
+    ch1   >  BUY_RULES.change1h
+  ) {
+    rec = 'GOOD';
+    why = ['Strong composite score'];
+    if (ch1   > 0) why.push('Positive 1h momentum');
+    if (ch24  > 0) why.push('Up over 24h');
+    if (liq   > 0) why.push('Healthy liquidity');
+    if (vol24 > 0) why.push('Active trading volume');
+  } else if (score >= 0.40) {
+    rec = 'WATCH';
+    why = ['Decent composite score'];
+    if (ch1 < 0) why.push('Short-term dip (entry risk)');
+    if (penaltyApplied) why.push('FDV/liquidity imbalance');
+  } else {
+    if (ch24 < 0)      why.push('Down over 24h');
+    if (liq  < 25_000) why.push('Thin liquidity');
+    if (vol24 < 50_000)why.push('Low trading activity');
+  }
+
+  out.score = score;
+  out.recommendation = rec;
+  out.why = why;
+
+  out._norm = {
+    nVol,
+    nLiq,
+    nMom: clamp((nMom + 1) / 2, 0, 1), 
+    nAct,
+  };
+  out._chg = [ch5, ch1, ch6, ch24]; 
+
+  return out;
+}
+
+export function scoreAndRecommend(rows){
+  const scored = rows.map(row => scoreAndRecommendOne(row));
+  return scored.sort((a, b) => b.score - a.score || b.volume.h24 - a.volume.h24);
 }

--- a/src/styles/profile.css
+++ b/src/styles/profile.css
@@ -263,9 +263,147 @@
 .stat .v { font-size:16px; font-weight:700; min-height:1em }
 .stat .v.sk { color: transparent; background: linear-gradient(90deg, rgba(255,255,255,.06), rgba(255,255,255,.14), rgba(255,255,255,.06)); background-size:200% 100%; animation: sh 1.2s linear infinite; border-radius:6px }
 
+.stat .k {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.stat .k .k__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stat .k .status {
+  min-width: 1.2em;
+  text-align: right;
+  opacity: .95;
+  filter: drop-shadow(0 0 0 rgba(0,0,0,0)); 
+}
+
+.stat .k .status.ok   { color: #1aff7a; }  
+.stat .k .status.warn { color: #ff4d6d; }
+
+@media (max-width: 520px) {
+  .profile__stats .stat::before {}
+}
+
+
 .profile__grid { display:grid; grid-template-columns: repeat(auto-fit, minmax(300px,1fr)); gap:12px }
 .profile__card { background: var(--card); border:1px solid rgba(122,222,255,.10); padding:12px; border-radius:14px }
 svg.bars rect { fill: rgba(123,241,255,.8) }
+
+.reco {
+  background: var(--card);
+  border: 1px solid rgba(122,222,255,.10);
+  border-radius: 14px;
+  padding: 12px;
+  margin-top: 10px;
+}
+
+.reco__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.reco__score {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+.reco__score__label { color: var(--muted); font-size: 12px; letter-spacing: .06em; text-transform: uppercase; }
+.reco__score__val   { font-weight: 800; font-size: 18px; }
+
+.reco__bars {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+  margin-top: 6px;
+  margin-bottom: 8px;
+}
+@media (min-width: 720px) {
+  .reco__bars {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.reco__row {
+  display: grid;
+  grid-template-columns: 9rem 1fr 3.5rem;
+  align-items: center;
+  gap: 8px;
+}
+.reco__row__label {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.reco__row__val {
+  text-align: right;
+  font-weight: 700;
+}
+
+.reco__bar {
+  position: relative;
+  height: 10px;
+  background: rgba(123,241,255,.08);
+  border: 1px solid rgba(123,241,255,.12);
+  border-radius: 999px;
+  overflow: hidden;
+}
+.reco__bar__fill {
+  height: 100%;
+  background: linear-gradient(90deg, rgba(26,255,213,.65), rgba(123,241,255,.85));
+  box-shadow: 0 0 10px rgba(26,255,213,.25) inset;
+  width: 0%;
+  transition: width .25s ease;
+}
+
+.reco__kpis {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 8px;
+  margin: 6px 0 8px;
+}
+.reco__kpi {
+  background: rgba(255,255,255,.02);
+  border: 1px dashed rgba(123,241,255,.12);
+  border-radius: 10px;
+  padding: 8px;
+}
+.reco__kpi__k { color: var(--muted); font-size: 12px; margin-bottom: 4px; }
+.reco__kpi__v { font-weight: 700; }
+
+.chip {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  border: 1px solid rgba(123,241,255,.18);
+}
+.chip.good { background: rgba(26,255,122,.12); }
+.chip.bad  { background: rgba(255,77,109,.12); }
+.chip.neutral { background: rgba(123,241,255,.10); }
+
+.reco__whywrap { margin-top: 6px; }
+.reco__why {
+  margin: 0;
+  padding-left: 18px;
+  line-height: 1.5;
+}
+.reco__why li { margin: 4px 0; }
+
+.reco[data-reco="good"]  { border-color: rgba(26,255,122,.25); }
+.reco[data-reco="watch"] { border-color: rgba(123,241,255,.18); }
+.reco[data-reco="avoid"] { border-color: rgba(255,77,109,.25); }
+
 
 .label { font-size:12px; letter-spacing:.08em; text-transform:uppercase; color: var(--muted); margin-bottom:8px }
 .reasons { margin:0; padding-left:18px; line-height:1.5 }
@@ -276,7 +414,7 @@ svg.bars rect { fill: rgba(123,241,255,.8) }
 .pairs th { text-align:left; color: var(--muted); font-weight:600 }
 .pairs td:last-child { text-align:right }
 
-.badge { display:inline-block; padding:5px 10px; border-radius:999px; font-weight:800; font-size:12px; color:#111 }
+.badge { display:inline-block; padding:5px 10px; border-radius:999px; font-weight:800; font-size:12px; }
 .badge.buy   { background: var(--buy) }
 .badge.watch { background: var(--watch) }
 .badge.avoid { background: var(--avoid) }

--- a/src/ui/profile.js
+++ b/src/ui/profile.js
@@ -1,5 +1,6 @@
-import { FALLBACK_LOGO } from "../config/env.js";
+import { FALLBACK_LOGO, BUY_RULES, FDV_LIQ_PENALTY } from "../config/env.js";
 import { fetchTokenInfo } from "../data/dexscreener.js";
+import { scoreAndRecommendOne } from "../core/calculate.js";
 import { normalizeSocial, iconFor } from "../data/socials.js";
 import { mountGiscus } from "./chat.js";
 import { loadAds, pickAd, adCard } from "../ads/load.js";
@@ -23,6 +24,99 @@ style.rel = 'stylesheet';
 style.href = '/src/styles/profile.css';
 document.head.appendChild(style);
 
+function pct(x){ return Number.isFinite(x) ? Math.max(0, Math.min(1, x))*100 : 0; }
+
+function recoBar(label, value01, hint=''){
+  const val = Number.isFinite(value01) ? Math.max(0, Math.min(1, value01)) : 0;
+  const aria = Math.round(val*100);
+  return `
+    <div class="reco__row">
+      <div class="reco__row__label" title="${esc(hint)}">${esc(label)}</div>
+      <div class="reco__bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${aria}" title="${aria}%">
+        <div class="reco__bar__fill" style="width:${(val*100).toFixed(0)}%"></div>
+      </div>
+      <div class="reco__row__val">${aria}%</div>
+    </div>
+  `;
+}
+
+function booleanChip(ok, { good='OK', bad='Issue', neutral='—' } = {}){
+  if (ok === null) return `<span class="chip neutral">${esc(neutral)}</span>`;
+  return ok ? `<span class="chip good">${esc(good)}</span>`
+            : `<span class="chip bad">${esc(bad)}</span>`;
+}
+
+function kpi(label, html, tooltip=''){
+  return `
+    <div class="reco__kpi" title="${esc(tooltip)}">
+      <div class="reco__kpi__k">${esc(label)}</div>
+      <div class="reco__kpi__v">${html}</div>
+    </div>
+  `;
+}
+
+function mountRecommendationPanel(args = {}) {
+  const { scored, token, checks = {} } = args;
+  const { LIQFDV_OK = null, VLIQR_OK = null, BUYR_OK = null } = checks;
+
+  const grid = document.getElementById('statsGrid');
+  if (!grid) return;
+
+  const wrap = document.createElement('div');
+  wrap.className = 'reco';
+  wrap.setAttribute('data-reco', String(scored?.recommendation || '').toLowerCase());
+
+  const barsHtml = [
+    recoBar('Composite Score', scored?.score ?? 0, 'Weighted volume+liquidity+momentum+activity'),
+    recoBar('Volume',   scored?._norm?.nVol ?? 0, 'Normalized log volume'),
+    recoBar('Liquidity',scored?._norm?.nLiq ?? 0, 'Normalized log liquidity'),
+    recoBar('Momentum', scored?._norm?.nMom ?? 0, 'Blended 1h/6h/24h; negatives penalized'),
+    recoBar('Activity', scored?._norm?.nAct ?? 0, 'Normalized txn count (24h)'),
+  ].join('');
+
+  const liqPctNeeded = (100 / Math.max(FDV_LIQ_PENALTY.ratio || 1, 1));
+  const kpisHtml = [
+    kpi('FDV/Liq balance',
+      booleanChip(LIQFDV_OK, { good: 'Balanced', bad: 'Imbalance' }),
+      `Needs ≥ ${liqPctNeeded.toFixed(2)}% liquidity-to-FDV`),
+    kpi('Turnover 24h',
+      (Number.isFinite(token?.volToLiq24h) ? `${token.volToLiq24h.toFixed(2)}×` : '—')
+      + ' ' + booleanChip(VLIQR_OK, { good: 'Healthy', bad: 'Low', neutral: '' })),
+    kpi('Buy Ratio 24h',
+      (Number.isFinite(token?.buySell24h) ? `${(token.buySell24h*100).toFixed(1)}%` : '—')
+      + ' ' + booleanChip(BUYR_OK, { good: 'Buy ≥ 50%', bad: 'Sell ≥ 50%', neutral: '' })),
+    kpi('Txns 24h',
+      (Number.isFinite(token?.tx24h?.buys) && Number.isFinite(token?.tx24h?.sells))
+        ? `${fmtNum(token.tx24h.buys + token.tx24h.sells)}`
+        : '—',
+      'Sum of buys + sells in 24h'),
+    kpi('Pairs', fmtNum(token?.pairs?.length || 0)),
+    kpi('Age', relTime(token?.ageMs || NaN)),
+  ].join('');
+
+  const why = Array.isArray(scored?.why) ? scored.why : [];
+  const whyHtml = why.length
+    ? `<ul class="reco__why">${why.map(w => `<li>${esc(w)}</li>`).join('')}</ul>`
+    : `<div class="muted small">No additional notes.</div>`;
+
+  wrap.innerHTML = `
+    <div class="reco__header">
+      <span class="badge ${cssReco(scored?.recommendation)}">${esc(scored?.recommendation)}</span>
+      <div class="reco__score">
+        <span class="reco__score__label">Score</span>
+        <span class="reco__score__val">${Math.round(((scored?.score) || 0) * 100)}%</span>
+      </div>
+    </div>
+    <div class="reco__bars">${barsHtml}</div>
+    <div class="reco__kpis">${kpisHtml}</div>
+    <div class="reco__whywrap">
+      <div class="label">Why</div>
+      ${whyHtml}
+    </div>
+  `;
+
+  grid.after(wrap); 
+}
 function debounce(fn, ms=120){
   let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn(...args), ms); };
 }
@@ -43,7 +137,7 @@ const pill = (x) => {
 
 const cssReco = (reco) => {
   const r = (reco || "watch").toLowerCase();
-  return r === "buy" ? "buy" : r === "avoid" ? "avoid" : "watch";
+  return r === "good" ? "good" : r === "avoid" ? "avoid" : "watch";
 };
 
 const STAT_DEF = [
@@ -71,12 +165,32 @@ function buildStatsGrid(container) {
     card.setAttribute('data-stat', s.key);
     card.setAttribute('data-short', s.short || s.label);
     card.innerHTML = `
-      <div class="k">${esc(s.label)}</div>
+      <div class="k">
+        <span class="k__text">${esc(s.label)}</span>
+        <span class="status" aria-hidden="true"></span>
+      </div>
       <div class="v sk" aria-live="polite" aria-atomic="true">—</div>
     `;
     frag.appendChild(card);
   }
   container.replaceChildren(frag);
+}
+
+function enableAutoShortLabels() {
+  const cards = elApp?.querySelectorAll('.profile__stats .stat');
+  if (!cards?.length) return;
+
+  const ro = new ResizeObserver(entries => {
+    for (const { target, contentRect } of entries) {
+      const short = target.getAttribute('data-short') || '';
+      const textEl = target.querySelector('.k__text');
+      if (!textEl) continue;
+      const long = textEl.dataset.long || textEl.textContent;
+      if (!textEl.dataset.long) textEl.dataset.long = long;
+      textEl.textContent = (contentRect.width < 180 && short) ? short : long;
+    }
+  });
+  cards.forEach(c => ro.observe(c));
 }
 
 function setupStatsCollapse(gridEl) {
@@ -150,7 +264,6 @@ function setupExtraMetricsToggle(cardEl) {
   btn.addEventListener('keydown', (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle(); } });
 }
 
-
 function renderBarChart(mount, vals = [], { height = 72, pad = 4, max = null, labels = [] } = {}) {
   if (!mount) return;
   const draw = () => {
@@ -194,9 +307,36 @@ function errorNotice(msg) {
   `;
 }
 
+function setStatStatusByKey(key, { ok = null, reason = '' } = {}) {
+  const el = elApp?.querySelector(`.profile__stats .stat[data-stat="${key}"] .status`);
+  if (!el) return;
+
+  // reset
+  el.classList.remove('ok', 'warn');
+  el.removeAttribute('title');
+  el.textContent = '';
+
+  if (ok === null) return;
+
+  if (ok) {
+    el.classList.add('ok');
+    el.textContent = '✅';
+    if (reason) el.title = reason;
+    el.setAttribute('role', 'img');
+    el.setAttribute('aria-label', 'Approved');
+  } else {
+    el.classList.add('warn');
+    el.textContent = '⚠️';
+    if (reason) el.title = reason;
+    el.setAttribute('role', 'img');
+    el.setAttribute('aria-label', 'Warning');
+  }
+}
+
 let CURRENT_AD = null;
 
 export async function renderProfileView(input, { onBack } = {}) {
+  const mint = typeof input === "string" ? input : input?.mint;
   const adsPromise = loadAds();
   try {
     const ads = await adsPromise;
@@ -205,9 +345,18 @@ export async function renderProfileView(input, { onBack } = {}) {
     CURRENT_AD = null;
   }
   const adHtml = CURRENT_AD ? adCard(CURRENT_AD) : '';
+  let t;
+  try {
+    t = await fetchTokenInfo(mint);
+    if (t.error) return errorNotice(t.error);
+  } catch (e) {
+    console.warn("fetchTokenInfo failed:", e);
+    window.location.href="/";
+  }
+  const scored = scoreAndRecommendOne(t);
   if (elHeader) elHeader.style.display = "none";
   if (!elApp) return;
-  const mint = typeof input === "string" ? input : input?.mint;
+
   if (!mint) {
     elApp.innerHTML = `<div class="wrap"><div class="small">Token not found. <a data-link href="/">Home</a></div></div>`;
     return;
@@ -222,7 +371,7 @@ export async function renderProfileView(input, { onBack } = {}) {
           <div class="title">Token</div>
           <div class="titleMint"><span class="muted mono">${esc(shortMint)}</span></div>
           <div class="row">
-            <span class="badge ${cssReco(input?.reco)}">${esc(input?.reco || "WATCH")}</span>
+            <span class="badge GOOD">GOOD</span>
           </div>
         </div>
         <div class="profile__links" id="profileLinks"></div>
@@ -265,6 +414,7 @@ export async function renderProfileView(input, { onBack } = {}) {
   `;
 
   buildStatsGrid(document.getElementById('statsGrid'));
+  enableAutoShortLabels();
   setupStatsCollapse(document.getElementById('statsGrid'));
   setupExtraMetricsToggle(document.querySelector('.profile__card__extra_metrics')); 
 
@@ -287,15 +437,6 @@ export async function renderProfileView(input, { onBack } = {}) {
     const svg = window.sparklineSVG(input.changes, { w: 560, h: 96 });
     const mount = document.getElementById("sparkProfile");
     if (mount) mount.innerHTML = svg;
-  }
-
-  let t;
-  try {
-    t = await fetchTokenInfo(mint);
-    if (t.error) return errorNotice(t.error);
-  } catch (e) {
-    console.warn("fetchTokenInfo failed:", e);
-    window.location.href="/";
   }
 
   const logo = t.imageUrl || FALLBACK_LOGO(t.symbol);
@@ -329,6 +470,42 @@ export async function renderProfileView(input, { onBack } = {}) {
   setStat(10, relTime(t.ageMs));
   setStat(11, `${fmtNum(t.tx24h.buys)} / ${fmtNum(t.tx24h.sells)}`);
   setStat(12, Number.isFinite(t.buySell24h) ? `${(t.buySell24h*100).toFixed(1)}% buys` : "—");
+  const LIQ_OK   = Number.isFinite(t.liquidityUsd) && t.liquidityUsd >= BUY_RULES.liq;
+  const VOL_OK   = Number.isFinite(t.v24hTotal)    && t.v24hTotal    >= BUY_RULES.vol24;
+  const CH1H_OK  = Number.isFinite(t.change1h)     && t.change1h     >  BUY_RULES.change1h;
+  const liqToFdvPct = Number.isFinite(t.liqToFdvPct) ? t.liqToFdvPct : null;
+  const minLiqPct   = 100 / Math.max(FDV_LIQ_PENALTY.ratio || 1, 1); 
+  const LIQFDV_OK   = Number.isFinite(liqToFdvPct) ? (liqToFdvPct >= minLiqPct) : null;
+  const CH6H_OK  = Number.isFinite(t.change6h)  ? t.change6h  > 0 : null;
+  const CH24H_OK = Number.isFinite(t.change24h) ? t.change24h > 0 : null;
+  const VLIQR_OK = Number.isFinite(t.volToLiq24h) ? t.volToLiq24h >= 0.5 : null;
+  const BUYR_OK  = Number.isFinite(t.buySell24h) ? (t.buySell24h >= 0.5) : null;
+  setStatStatusByKey('liq',    { ok: LIQ_OK,   reason: LIQ_OK ? 'Meets liquidity rule' : `Needs ≥ ${Intl.NumberFormat().format(BUY_RULES.liq)} liquidity` });
+  setStatStatusByKey('fdv',    { ok: null });
+  setStatStatusByKey('liqfdv', { ok: LIQFDV_OK, reason: LIQFDV_OK === null ? '' : (LIQFDV_OK ? 'FDV/Liq is balanced' : 'FDV/Liq imbalance detected') });
+  setStatStatusByKey('v24',    { ok: VOL_OK,   reason: VOL_OK ? 'Meets 24h volume rule' : `Needs ≥ ${nfCompact.format(BUY_RULES.vol24)} 24h volume` });
+  setStatStatusByKey('vliqr',  { ok: VLIQR_OK, reason: VLIQR_OK === null ? '' : (VLIQR_OK ? 'Healthy 24h turnover vs liquidity' : 'Low turnover vs liquidity') });
+  setStatStatusByKey('d1h',    { ok: CH1H_OK,  reason: CH1H_OK ? 'Positive 1h momentum' : `Needs > ${BUY_RULES.change1h.toFixed(2)}% 1h change` });
+  setStatStatusByKey('d6h',    { ok: CH6H_OK,  reason: CH6H_OK ? 'Up over 6h' : 'Down over 6h' });
+  setStatStatusByKey('d24h',   { ok: CH24H_OK, reason: CH24H_OK ? 'Up over 24h' : 'Down over 24h' });
+  setStatStatusByKey('price',  { ok: null });
+  setStatStatusByKey('d5m',    { ok: null });
+  setStatStatusByKey('age',    { ok: null });
+  const buys = t?.tx24h?.buys, sells = t?.tx24h?.sells;
+  const txKnown = Number.isFinite(buys) && Number.isFinite(sells);
+  const TX_OK = txKnown ? (buys + sells) > 0 : null;
+  setStatStatusByKey('bs24',   { ok: TX_OK, reason: TX_OK === null ? '' : (TX_OK ? '24h trading present' : 'No 24h trades') });
+  setStatStatusByKey('buyratio', { ok: BUYR_OK, reason: BUYR_OK === null ? '' : (BUYR_OK ? 'Buy pressure ≥ 50%' : 'Sell pressure ≥ 50%') });
+  const badgeWrap = elApp.querySelector('.profile__hero .row');
+  if (badgeWrap) {
+    badgeWrap.innerHTML = `<span class="badge ${cssReco(scored.recommendation)}">${esc(scored.recommendation)}</span>`;
+  }
+
+  mountRecommendationPanel({
+    scored,
+    token: t,
+    checks: { LIQFDV_OK, VLIQR_OK, BUYR_OK }
+  });
 
   const mom = [t.change5m, t.change1h, t.change6h, t.change24h].map(x => Number.isFinite(x) ? Math.max(0, x) : 0);
   const momBox = document.getElementById("momBars");


### PR DESCRIPTION
…ingle-item scorer

Add scoreAndRecommendOne() and refactor scoreAndRecommend() to delegate to it to keep logic single-sourced.

Profile view:

- Inject ✅/⚠️ status icons into stat labels based on BUY_RULES and FDV_LIQ_PENALTY (with tooltips)

- Auto short labels on narrow stat cards via ResizeObserver

- New bottom-of-stats Recommendation panel with:

    • Overall badge + composite score

    • Component bars (Volume/Liquidity/Momentum/Activity) using normalized values

    • KPIs: FDV/Liq balance, 24h turnover (Vol/Liq), Buy ratio, Txns 24h, Pairs, Age

    • 'Why' list sourced from scoring reasons

- Accessibility: role=progressbar, aria-valuenow, aria labels for status glyphs

- Responsive layout for bars and KPIs

Fixes:

- Avoid ReferenceError by destructuring checks with safe defaults inside mountRecommendationPanel()

- Actually mount the recommendation panel after stats are rendered

Styles:

- Add .reco* styles (panel, bars, KPIs, chips, why list) and subtle border accent by recommendation

- Tweak stat header to host inline status icon