### PR TITLE
feat(profile,swap): live feed, stream toggle, mobile Phantom swap lin…

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -328,7 +328,7 @@ input[type="checkbox"]:disabled{
 .btn{
   display:inline-flex; align-items:center; gap:8px; padding:9px 12px; border-radius:12px; font-weight:600; letter-spacing:.2px;
   background: linear-gradient(90deg, rgb(0 0 0 / 15%), rgb(11 156 173 / 15%));
-  border:1px solid rgba(122,222,255,.28); color:var(--text); text-decoration:none
+  border:1px solid rgba(122,222,255,.28); color:var(--text); text-decoration:none; cursor: pointer;
 }
 .btn:hover{filter:brightness(1.1)}
 .btn.buy{border-color: rgba(26,255,122,.45); box-shadow: inset 0 0 0 1px rgba(26,255,122,.2)}
@@ -839,7 +839,7 @@ hr.sep{border:0; border-top:1px dashed rgba(122,222,255,.2); margin:10px 0}
 
 .fdv-modal-header{
   display:flex; gap:12px; align-items:flex-start; justify-content:space-between;
-  padding:14px 16px; border-bottom:1px solid var(--fdv-border);
+  padding:14px 16px; border-bottom: 1px solid var(--fdv-border);
 }
 .fdv-title-wrap{width: 100%;}
 .fdv-header-controls {

--- a/src/views/profile/render/shell.js
+++ b/src/views/profile/render/shell.js
@@ -19,7 +19,7 @@ export default function renderShell({ mount, mint, adHtml = "" }) {
       <div class="profile__navigation">
         <a class="btn buy-btn disabled" id="btnTradeTop" target="_blank" rel="noopener">Dexscreener</a>
         <div class="actions">
-          <button class="btn btn-ghost" id="btnCopyMint" title="Copy mint">Copy</button>
+          <button class="btn btn-ghost" id="btnCopyMint" title="Copy mint">Share</button>
           <button class="btn" id="btnBack">Back</button>
         </div>
       </div>


### PR DESCRIPTION
…k; clearer swap precheck logs

Profile: add abortable 2s live feed (fetchTokenInfoLive) that pauses when stream is Off; rescore on each tick and animate recommendation bars; live-patch stats grid and pairs table; persist Stream On/Off in localStorage, mirror header state, emit 'stream-state' for feed resume.

Swap: on mobile open Phantom universal swap URL (https://phantom.app/ul/swap/?buy=solana:101/address:<MINT>&sell=solana:101/address:<SOL>); desktop uses modal or Dex fallback. Make 'Quote & Swap' always clickable and _log why it's blocked when wallet not connected or verification missing; reflect state via aria-disabled/class and reset Turnstile if expired.

UI: add tick-up/down animations for KPI updates; theme fdv-log scrollbar. Fix: updateStatsGridLive selectors and pairs table render signature.