### PR TITLE
feat(addons): generic ingest + UI-only registry; KPIs self-register

### DIFF
--- a/src/views/meme/addons/das.js
+++ b/src/views/meme/addons/das.js
@@ -1,0 +1,142 @@
+import { addKpiAddon } from './ingest.js';
+
+export const DAS_STORAGE_KEY = 'meme_das_history_v1';
+export const DAS_WINDOW_DAYS = 3;           // lookback window
+export const DAS_SNAPSHOT_LIMIT = 400;      // global cap
+export const DAS_PER_MINT_CAP = 80;         // per-mint cap
+export const DAS_HALFLIFE_DAYS = 1.5;       // half-life for exponential decay
+const LN2 = Math.log(2);
+
+function loadDasHistory() {
+  try {
+    const raw = localStorage.getItem(DAS_STORAGE_KEY);
+    return raw ? JSON.parse(raw) : { byMint: {}, total: 0 };
+  } catch { return { byMint: {}, total: 0 }; }
+}
+function saveDasHistory(h) {
+  try { localStorage.setItem(DAS_STORAGE_KEY, JSON.stringify(h)); } catch {}
+}
+function pruneDasHistory(h) {
+  const cutoff = Date.now() - DAS_WINDOW_DAYS*24*3600*1000;
+  let total = 0;
+  for (const mint of Object.keys(h.byMint)) {
+    let arr = Array.isArray(h.byMint[mint]) ? h.byMint[mint] : [];
+    arr = arr.filter(e => +e.ts >= cutoff).slice(-DAS_PER_MINT_CAP);
+    if (arr.length) { h.byMint[mint] = arr; total += arr.length; }
+    else delete h.byMint[mint];
+  }
+  if (total > DAS_SNAPSHOT_LIMIT) {
+    const all = [];
+    for (const [mint, arr] of Object.entries(h.byMint)) {
+      for (const e of arr) all.push({ mint, ...e });
+    }
+    all.sort((a,b)=>a.ts-b.ts);
+    const keep = all.slice(-DAS_SNAPSHOT_LIMIT);
+    const next = { byMint: {}, total: keep.length };
+    for (const e of keep) {
+      (next.byMint[e.mint] ||= []).push({ ts: e.ts, score: e.score, kp: e.kp });
+    }
+    return next;
+  }
+  h.total = total;
+  return h;
+}
+
+export function updateDasHistory(items) {
+  const h = loadDasHistory();
+  const ts = Date.now();
+  const scored = (Array.isArray(items) ? items : []).map(it => ({
+    mint: it.mint || it.id,
+    symbol: it.symbol || '',
+    name: it.name || '',
+    imageUrl: it.imageUrl || it.logoURI || '',
+    pairUrl: it.pairUrl || '',
+    priceUsd: Number(it?.priceUsd) || 0,
+    chg24: Number(it?.change?.h24) || 0,
+    liqUsd: Number(it?.liquidityUsd) || 0,
+    vol24: Number(it?.volume?.h24) || 0,
+    score: Number(it?.score) || 0
+  }));
+  for (const it of scored) {
+    const entry = { ts, score: it.score, kp: it };
+    (h.byMint[it.mint] ||= []).push(entry);
+    if (h.byMint[it.mint].length > DAS_PER_MINT_CAP) {
+      h.byMint[it.mint] = h.byMint[it.mint].slice(-DAS_PER_MINT_CAP);
+    }
+  }
+  h.total = Object.values(h.byMint).reduce((a,arr)=>a+arr.length,0);
+  saveDasHistory(pruneDasHistory(h));
+}
+
+function computeDASForMint(arr, nowTs, halflifeDays = DAS_HALFLIFE_DAYS) {
+  if (!Array.isArray(arr) || !arr.length) return 0;
+  const lambda = LN2 / Math.max(1e-6, halflifeDays);
+  let wsum = 0, vsum = 0;
+
+  for (const e of arr) {
+    const ageDays = (nowTs - (+e.ts)) / (24*3600*1000);
+    if (ageDays < 0) continue;
+    const w = Math.exp(-lambda * ageDays);
+    if (!Number.isFinite(e.score)) continue;
+    wsum += w;
+    vsum += w * e.score;
+  }
+  if (wsum <= 0) return 0;
+  return Math.round(vsum / wsum);
+}
+
+export function computeDasLeaders(limit = 3) {
+  const h = pruneDasHistory(loadDasHistory());
+  const cutoff = Date.now() - DAS_WINDOW_DAYS*24*3600*1000;
+  const now = Date.now();
+  const agg = [];
+
+  for (const [mint, arr] of Object.entries(h.byMint)) {
+    const recent = (arr || []).filter(e => +e.ts >= cutoff);
+    if (!recent.length) continue;
+    const das = computeDASForMint(recent, now, DAS_HALFLIFE_DAYS);
+    const latest = recent[recent.length-1]?.kp || {};
+    agg.push({ mint, dasScore: das, kp: latest });
+  }
+
+  agg.sort((a,b)=> b.dasScore - a.dasScore);
+  return agg.slice(0, limit);
+}
+
+function mapAggToRegistryRows(agg) {
+  return agg.map(it => ({
+    mint: it.mint,
+    symbol: it.kp?.symbol || '',
+    name: it.kp?.name || '',
+    imageUrl: it.kp?.imageUrl || '',
+    priceUsd: it.kp?.priceUsd ?? 0,
+    chg24: it.kp?.chg24 ?? 0,
+    liqUsd: it.kp?.liqUsd ?? 0,
+    vol24: it.kp?.vol24 ?? 0,
+    pairUrl: it.kp?.pairUrl || '',
+    metric: it.dasScore
+  }));
+}
+addKpiAddon(
+  {
+    id: 'das',
+    order: 25,
+    label: 'DAS',
+    title: `Decay-Adjusted Leaders`,
+    metricLabel: 'DAS',
+    limit: 3,
+  },
+  {
+    computePayload() {
+      const agg = computeDasLeaders(3);
+      return {
+        title: `Decay-Adjusted Leaders`,
+        metricLabel: 'DAS',
+        items: mapAggToRegistryRows(agg),
+      };
+    },
+    ingestSnapshot(items) {
+      updateDasHistory(items);
+    }
+  }
+);

--- a/src/views/meme/addons/engagement.js
+++ b/src/views/meme/addons/engagement.js
@@ -1,4 +1,4 @@
-import { registerAddon, setAddonData } from './register.js';
+import { addKpiAddon } from './ingest.js';
 
 export const ENG_STORAGE_KEY = 'meme_engagement_history_v1';
 export const ENG_WINDOW_DAYS = 3;
@@ -169,35 +169,26 @@ function mapAggToRegistryRows(agg) {
   }));
 }
 
-function pushEngagementToRegistry() {
-  const agg = computeEngagementTop3();
-  setAddonData('engagement', {
-    title: `Most engaged tokens (last ${ENG_WINDOW_DAYS}d)`,
-    metricLabel: 'Engagement',
-    items: mapAggToRegistryRows(agg),
-  });
-}
-
-export function engagementTick() {
-  try { pushEngagementToRegistry(); } catch {}
-}
-export function engagementIngestSnapshot(items) {
-  try {
-    updateEngagementHistory(items);
-  } finally {
-    pushEngagementToRegistry();
-  }
-}
-
-export function registerEngagementAddon(opts = {}) {
-  const { order = 20, label = 'Engagement', limit = 3 } = opts;
-  registerAddon({
+addKpiAddon(
+  {
     id: 'engagement',
-    order,
-    label,
-    title: `Most engaged tokens (last ${ENG_WINDOW_DAYS}d)`,
+    order: 20,
+    label: 'Engagement',
+    title: `Most engaged tokens`,
     metricLabel: 'Engagement',
-    limit
-  });
-  pushEngagementToRegistry();
-}
+    limit: 3,
+  },
+  {
+    computePayload() {
+      const agg = computeEngagementTop3();
+      return {
+        title: `Most engaged tokens`,
+        metricLabel: 'Engagement',
+        items: mapAggToRegistryRows(agg),
+      };
+    },
+    ingestSnapshot(items) {
+      updateEngagementHistory(items);
+    }
+  }
+);

--- a/src/views/meme/addons/ingest.js
+++ b/src/views/meme/addons/ingest.js
@@ -1,1 +1,59 @@
-//I ate too many addons
+import { registerAddon, setAddonData, runAddonsTick, ensureAddonsUI } from './register.js';
+
+
+const ADDONS = new Map(); 
+let booted = false;
+
+export function addKpiAddon(def, handlers) {
+  if (!def || !def.id) return;
+  if (!handlers || typeof handlers.computePayload !== 'function') return;
+
+  if (!ADDONS.has(def.id)) {
+    ADDONS.set(def.id, { def: { ...def }, ...handlers });
+    try { registerAddon(def); } catch {}
+  } else {
+    const prev = ADDONS.get(def.id);
+    ADDONS.set(def.id, { def: { ...prev.def, ...def }, ...handlers });
+  }
+  if (booted) {
+    try { ensureAddonsUI(); } catch {}
+    try { pushAll(); } catch {}
+  }
+}
+
+function pushAll() {
+  for (const [id, a] of ADDONS) {
+    try {
+      const payload = a.computePayload();
+      if (payload && typeof payload === 'object') {
+        setAddonData(id, payload);
+      }
+    } catch {}
+  }
+  try { runAddonsTick(); } catch {}
+}
+
+export function ingestSnapshot(items) {
+  try {
+    if (Array.isArray(items) && items.length) {
+      for (const [, a] of ADDONS) {
+        try { a.ingestSnapshot?.(items); } catch {}
+      }
+    }
+  } finally {
+    pushAll();
+  }
+}
+(function boot() {
+  function init() {
+    booted = true;
+    try { ensureAddonsUI?.(); } catch {}
+    pushAll();
+  }
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+  window.pushMemeSnapshot = (items) => ingestSnapshot(items);
+})();

--- a/src/views/meme/addons/register.js
+++ b/src/views/meme/addons/register.js
@@ -1,10 +1,5 @@
-import { registerTop3Addon, top3IngestSnapshot, top3Tick } from './three.js';
-import { registerEngagementAddon, engagementIngestSnapshot, engagementTick } from './engagement.js';
-import { registerSmqAddon, smqTick } from './smq.js';
-
-
 const REGISTRY = [];
-const STATE = new Map(); // id -> { items: [], title?, subtitle?, metricLabel?, ts }
+const STATE = new Map(); 
 
 // side load css
 function ensureAddonStyles() {
@@ -231,38 +226,4 @@ export function setAddonData(id, data) {
 export function runTheAddonsTick() {
   runAddonsTick();
 }
-
-(function bootRegistry(){
-  try { registerTop3Addon({ order: 10, limit: 3 }); } catch {}
-  try { registerSmqAddon({ order: 15, limit: 3 }); } catch {}
-  try { registerEngagementAddon({ order: 20, limit: 3 }); } catch {}
-
-  function initDom() {
-    try { ensureAddonsUI(); } catch {}
-    try { top3Tick(); } catch {}
-    try { smqTick(); } catch {}
-    try { engagementTick(); } catch {}
-    try { runTheAddonsTick(); } catch {}
-  }
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', initDom, { once: true });
-  } else {
-    initDom();
-  }
-
-  window.pushMemeSnapshot = function(items){
-    try { top3IngestSnapshot(items); } catch {}
-    try { engagementIngestSnapshot(items); } catch {}
-    try { smqTick(); } catch {} // recompute from updated history
-    try { runTheAddonsTick(); } catch {}
-  };
-  window.addEventListener('meme:snapshot', (e) => {
-    const items = e?.detail?.items ?? e?.detail;
-    if (items) window.pushMemeSnapshot(items);
-  });
-
-  setInterval(() => {
-    try { runTheAddonsTick(); } catch {}
-  }, 2500);
-})();
 

--- a/src/views/meme/page.js
+++ b/src/views/meme/page.js
@@ -1,10 +1,17 @@
 import { MAX_CARDS } from '../../config/env.js';
 import { coinCard, priceHTML } from './cards.js';
-import { ensureAddonsUI, runAddonsTick } from './addons/register.js';
+import { ensureAddonsUI } from './addons/register.js';
+import { ingestSnapshot } from './addons/ingest.js';
 import { adCard } from '../../ads/load.js';
 import { sparklineSVG } from './render/sparkline.js';
 import { pctChipsHTML } from './render/chips.js';
 import { searchTokensGlobal } from '../../data/dexscreener.js';
+
+// Addons and KPIs
+import './addons/three.js';
+import './addons/smq.js';
+import './addons/engagement.js';
+import './addons/das.js';
 
 export const elCards    = document.getElementById('cards');
 export const elMeta     = document.getElementById('meta');
@@ -735,7 +742,9 @@ export function render(items, adPick, marquee) {
   _latestAd = adPick || null;
   _latestMarquee = marquee || null;
 
-  try { runAddonsTick({ items: Array.isArray(items) ? items : [], marquee }); } catch {}
+  // Push stream snapshot to KPI ingest (registry UI renders automatically)
+  try { ingestSnapshot(Array.isArray(items) ? items : []); } catch {}
+
   // renderAdTop();
   renderMarquee(_latestMarquee);
 


### PR DESCRIPTION
- add ingest.js with addKpiAddon() and snapshot buffering
- refactor register.js to UI/state-only
- update three/engagement/smq/das to compute-only and self-register
- page uses ingestSnapshot and side-effect KPI imports